### PR TITLE
Loosen dependency on base in a few packages

### DIFF
--- a/bytestring-rematch/bytestring-rematch.cabal
+++ b/bytestring-rematch/bytestring-rematch.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.8
 library
   -- exposed-modules:     
   -- other-modules:       
-  build-depends:       base ==4.5.*, bytestring >= 0.9
+  build-depends:       base >=4.5.0 && < 5, bytestring >= 0.9
 test-suite tests
   build-depends:       base >= 4.5.0 && < 5, hspec >= 1.4, HUnit >= 1.2, bytestring >= 0.9, rematch >= 0.2
   type: exitcode-stdio-1.0

--- a/hunit-rematch/hunit-rematch.cabal
+++ b/hunit-rematch/hunit-rematch.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.8
 library
   -- exposed-modules:     
   -- other-modules:       
-  build-depends:       base ==4.5.*, rematch >= 0.2, HUnit >= 1.2
+  build-depends:       base >= 4.5.0 && < 5, rematch >= 0.2, HUnit >= 1.2
   exposed-modules:     Test.Rematch.HUnit
 test-suite tests
   build-depends:       base >= 4.5.0 && < 5, hspec >= 1.4, HUnit >= 1.2, rematch >= 0.2

--- a/unordered-containers-rematch/unordered-containers-rematch.cabal
+++ b/unordered-containers-rematch/unordered-containers-rematch.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.8
 library
   exposed-modules: Control.Rematch.HashMap.Lazy, Control.Rematch.HashMap.Strict, Control.Rematch.HashSet
   -- other-modules:       
-  build-depends:       base ==4.5.*, unordered-containers >= 0.2, rematch >= 0.2, hashable >= 1.2
+  build-depends:       base >= 4.5.0 && < 5, unordered-containers >= 0.2, rematch >= 0.2, hashable >= 1.2
 test-suite tests
   build-depends:       base >= 4.5.0 && < 5, hspec >= 1.4, HUnit >= 1.2, unordered-containers >= 0.2, rematch >= 0.2, hashable >= 1.2
   type: exitcode-stdio-1.0


### PR DESCRIPTION
I saw that several packages depended on `base >= 4.5.0 && < 5` but a few
were specifying `4.5.x`, which prevents these packages from installing
with base 4.6. I loosened up the dependencies and ran the tests under
4.6 and they passed.
