### PR TITLE
Generalise list matchers to accept any Foldable instance.

### DIFF
--- a/core/rematch.cabal
+++ b/core/rematch.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                rematch
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            A simple api for matchers
 description:
     Rematch is a simple library of matchers, which express rules
@@ -26,9 +26,10 @@ build-type:          Simple
 cabal-version:       >=1.8
 
 library
-  exposed-modules:     Control.Rematch, Control.Rematch.Formatting, Control.Rematch.Run
-  build-depends:       base >= 4.5.0 && < 5
+  exposed-modules:     Control.Rematch, Control.Rematch.Formatting,
+                       Control.Rematch.Run, Control.Rematch.Traversable
+  build-depends:       base >= 4.8 && < 5
 test-suite tests
-  build-depends:       base >= 4.5.0 && < 5, hspec >= 1.4, HUnit >= 1.2
+  build-depends:       base >= 4.8 && < 5, hspec >= 1.4, HUnit >= 1.2
   type: exitcode-stdio-1.0
   main-is: Main.hs


### PR DESCRIPTION
This relies on the updated definitions of various functions in the base-4.8.0.0
Prelude, so have updated dependencies and bumped version number.  It may be
possible to revert to base-4.5.0.0 if desired by explicitly using Foldable
functions rather than defaulting to list functions, but as I don't have an
appropriate installation to test it on I've not done so.
