### PR TITLE
New list/foldable matching functions: isSingleton and followedBy

### DIFF
--- a/core/Control/Rematch/Data.hs
+++ b/core/Control/Rematch/Data.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DeriveDataTypeable, FlexibleInstances, OverlappingInstances #-}
+{-# LANGUAGE NoMonomorphismRestriction, UndecidableInstances, RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Matchers based on the 'Data' type class defined in @Data.Data@.
+--
+-- Examples below are based on a sample data type defined as
+-- @data MyType = First | Second Int | Third String Bool deriving(Data,Show)@.
+
+module Control.Rematch.Data (Constrable, isDataConstr, isDataValue) where
+
+import Data.Data
+import Control.Rematch
+
+-- | class Constrable allows us to convert an algebraic data type constructor
+-- function (e.g. 'Maybe') to a 'Constr' object that represents the values
+-- it can create. Based on code provided by Tikhon Jelvis in a Stack Overflow
+-- answer (see http://stackoverflow.com/a/25588663/441899)
+class Constrable a where
+  constr :: a -> Constr
+
+instance Data a => Constrable a where
+  constr = toConstr
+
+instance Constrable a => Constrable (b -> a) where
+  constr f = constr (f undefined)
+
+-- | Match if and only if a value was constructed using a specific constructor
+-- version, e.g. @isDataConstr Second@ produces a matcher for @MyType@ that
+-- accepts values produced via @Second@ but rejects those produced via @First@
+-- or @Third@
+isDataConstr :: (Data d, Constrable c) => c -> Matcher d
+isDataConstr f = Matcher match
+                         ("value with constructor " ++ show expectedC)
+                         (\v -> "had constructor " ++ (show $ toConstr v))
+                 where
+                   expectedC = constr f
+                   match v = toConstr v == expectedC
+
+-- | Match if and only if a value was specified using a specific constructor
+-- and contains an argument at a specified zero-based index.  For example,
+-- @isDataValue Second 0 (equalTo (2::Int))@ is a matcher for @MyType@ that will
+-- first check that the value was constructed via the @Second@ constructor, then
+-- that the type of value contained is an 'Int', and finally that it is equal to
+-- 3.
+--
+-- Note that types of contained values are checked *dynamically* not
+-- *statically*, as the 'Data' type class does not provide static type
+-- information about constructor arguments.  For this reason, when checking
+-- against literals that may have multiple types, it is important to
+-- specify their types explicitly, otherwise they may be defaulted to the
+-- wrong the type.
+isDataValue :: forall c v d . (Data d, Constrable c, Data v, Show d) =>
+               c -> Int -> Matcher v -> Matcher d
+isDataValue f i argMatch =
+    Matcher doMatch descr standardMismatch
+    where
+      expectedC = constr f
+      descr = "value with constructor " ++ (show expectedC) ++ " with "
+              ++ (description argMatch) ++ " at index " ++ (show i)
+      doMatch v = toConstr v == expectedC &&
+                gmapQi i doSubmatch v
+      doSubmatch :: forall ad . Data ad => ad -> Bool
+      doSubmatch av = case (cast av) :: Maybe v of
+                        Just avx -> (match argMatch) avx
+                        Nothing  -> False
+
+
+-- FIXME need tests for both matchers defined in this module

--- a/core/Control/Rematch/Specs.hs
+++ b/core/Control/Rematch/Specs.hs
@@ -110,6 +110,19 @@ listMatcherSpecs = describe "list matchers" $ do
 
   it "hasSize" pending
 
+  describe "isSingleton" $ do
+    it "does not match when there are no items" $
+       checkMatch (isSingleton $ equalTo 1) [] @?= Just ("isSingleton(equalTo 1)", "got an empty list: []")
+
+    it "matches when one item matches" $
+       checkMatch (isSingleton $ equalTo 1) [1] @?= Nothing
+
+    it "does not match when one item does not match" $
+       checkMatch (isSingleton $ equalTo 1) [2] @?= Just ("isSingleton(equalTo 1)", "was 2")
+
+    it "does not match when there are two items" $
+       checkMatch (isSingleton $ equalTo 1) [1, 1] @?= Just ("isSingleton(equalTo 1)", "got a list with multiple items: [1,1]")
+
 comparableSpecs :: Spec
 comparableSpecs = describe "comparables" $ do
   describe "greaterThan" $ do

--- a/core/Control/Rematch/Specs.hs
+++ b/core/Control/Rematch/Specs.hs
@@ -123,6 +123,18 @@ listMatcherSpecs = describe "list matchers" $ do
     it "does not match when there are two items" $
        checkMatch (isSingleton $ equalTo 1) [1, 1] @?= Just ("isSingleton(equalTo 1)", "got a list with multiple items: [1,1]")
 
+  describe "followedBy" $ do
+    it "does not match if there are no items" $
+       checkMatch (is 1 `followedBy` isEmpty) [] @?= Just ("equalTo 1 followed by isEmpty", "got an empty list: []")
+    it "matches if the inputs match its arguments" $
+       checkMatch (is 1 `followedBy` isEmpty) [1] @?= Nothing
+    it "fails if the first argument does not match the head" $
+       checkMatch (is 1 `followedBy` isEmpty) [2] @?= Just ("equalTo 1 followed by isEmpty", "was 2")
+    it "fails if the second argument does not match the tail" $
+       checkMatch (is 1 `followedBy` isSingleton $ equalTo 2) [1,4] @?= Just ("equalTo 1 followed by isSingleton(equalTo 2)", "matched 1, was 4")
+    it "includes match description of the tail when first argument does not match" $
+       checkMatch (is 1 `followedBy` is 2 `followedBy` isEmpty) [2,2] @?= Just ("equalTo 1 followed by equalTo 2 followed by isEmpty", "was 2, matched 2")
+
 comparableSpecs :: Spec
 comparableSpecs = describe "comparables" $ do
   describe "greaterThan" $ do

--- a/core/rematch.cabal
+++ b/core/rematch.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                rematch
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            A simple api for matchers
 description:
     Rematch is a simple library of matchers, which express rules
@@ -26,9 +26,10 @@ build-type:          Simple
 cabal-version:       >=1.8
 
 library
-  exposed-modules:     Control.Rematch, Control.Rematch.Formatting, Control.Rematch.Run
-  build-depends:       base >= 4.5.0 && < 5
+  exposed-modules:     Control.Rematch, Control.Rematch.Formatting,
+                       Control.Rematch.Run, Control.Rematch.Traversable
+  build-depends:       base >= 4.8 && < 5
 test-suite tests
-  build-depends:       base >= 4.5.0 && < 5, hspec >= 1.4, HUnit >= 1.2
+  build-depends:       base >= 4.8 && < 5, hspec >= 1.4, HUnit >= 1.2
   type: exitcode-stdio-1.0
   main-is: Main.hs

--- a/core/rematch.cabal
+++ b/core/rematch.cabal
@@ -27,7 +27,8 @@ cabal-version:       >=1.8
 
 library
   exposed-modules:     Control.Rematch, Control.Rematch.Formatting,
-                       Control.Rematch.Run, Control.Rematch.Traversable
+                       Control.Rematch.Run, Control.Rematch.Traversable,
+                       Control.Rematch.Data
   build-depends:       base >= 4.8 && < 5
 test-suite tests
   build-depends:       base >= 4.8 && < 5, hspec >= 1.4, HUnit >= 1.2

--- a/tasty-hunit-rematch/LICENSE
+++ b/tasty-hunit-rematch/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2013 Tom Crayford
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tasty-hunit-rematch/Main.hs
+++ b/tasty-hunit-rematch/Main.hs
@@ -1,0 +1,4 @@
+import qualified Test.Rematch.Specs.TastyHUnit as S
+
+main :: IO ()
+main = S.main

--- a/tasty-hunit-rematch/Setup.hs
+++ b/tasty-hunit-rematch/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tasty-hunit-rematch/Test/Rematch/Specs/TastyHUnit.hs
+++ b/tasty-hunit-rematch/Test/Rematch/Specs/TastyHUnit.hs
@@ -1,0 +1,17 @@
+module Test.Rematch.Specs.TastyHUnit where
+import Test.Hspec
+import Test.Hspec.HUnit()
+import Test.Rematch.HUnit
+import Control.Rematch(is)
+
+main :: IO ()
+main = hspec $ specs
+
+specs :: Spec
+specs = do
+  describe "expect" $ do
+    -- it isn't clear how to run a tasty test programatically and extract its result,
+    -- so I'm not sure how to write a test for this.
+    it "is used as a tasty-hunit test" pending
+
+       

--- a/tasty-hunit-rematch/Test/Rematch/TastyHUnit.hs
+++ b/tasty-hunit-rematch/Test/Rematch/TastyHUnit.hs
@@ -1,0 +1,18 @@
+module Test.Rematch.TastyHUnit where
+import Test.Tasty.HUnit(Assertion, assertFailure)
+import Control.Rematch
+import Control.Rematch.Run
+
+-- |Run a matcher as a Tasty HUnit assertion
+--
+-- Example output:
+--
+-- @
+--Expected: equalTo "a"
+--     but: was "b"
+-- @
+expect :: a -> Matcher a -> Assertion
+expect a matcher = case res of
+  MatchSuccess -> return ()
+  (MatchFailure msg) -> assertFailure msg
+  where res = runMatch matcher a

--- a/tasty-hunit-rematch/script/test
+++ b/tasty-hunit-rematch/script/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+runghc Test/Rematch/Specs/HUnit.hs

--- a/tasty-hunit-rematch/tasty-hunit-rematch.cabal
+++ b/tasty-hunit-rematch/tasty-hunit-rematch.cabal
@@ -1,0 +1,23 @@
+name:                tasty-hunit-rematch
+version:             0.1.0.1
+synopsis:            Tasty-HUnit support for rematch
+-- description:         
+homepage:            http://github.com/tcrayford/rematch
+license:             MIT
+license-file:        LICENSE
+author:              Tom Crayford
+maintainer:          tcrayford@googlemail.com
+-- copyright:           
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.8
+
+library
+  -- exposed-modules:     
+  -- other-modules:       
+  build-depends:       base >= 4.5.0 && < 5, rematch >= 0.2, tasty-hunit >= 0.9
+  exposed-modules:     Test.Rematch.TastyHUnit
+test-suite tests
+  build-depends:       base >= 4.5.0 && < 5, hspec >= 1.4, tasty-hunit >= 0.9, rematch >= 0.2
+  type: exitcode-stdio-1.0
+  main-is: Main.hs


### PR DESCRIPTION
isSingleton matches a list or other Foldable instance that contains only a single item
followedBy matches a list or Foldable by matching the head to one matcher and the tail to another
These changes rely on the Foldable changes from pull request #9 , so presumably are also going to break your CI build for the same reason.  If you prefer them without the Foldable changes it should be trivial to change them to work only on lists.
